### PR TITLE
List of miner UIDs passed to get_rewards

### DIFF
--- a/bitagent/validator/forward.py
+++ b/bitagent/validator/forward.py
@@ -62,7 +62,7 @@ async def forward(self):
 
     # Adjust the scores based on responses from miners.
     # also gets results for feedback to the miners
-    rewards, results = get_rewards(self, task=task, responses=responses, miner_uids=miner_uids.tolist())
+    rewards, results = get_rewards(self, task=task, responses=responses, miner_uids=miner_uids)
 
     bt.logging.info(f"Scored responses: {rewards}")
     # Update the scores based on the rewards. You may want to define your own update_scores function for custom behavior.

--- a/bitagent/validator/forward.py
+++ b/bitagent/validator/forward.py
@@ -62,7 +62,7 @@ async def forward(self):
 
     # Adjust the scores based on responses from miners.
     # also gets results for feedback to the miners
-    rewards, results = get_rewards(self, task=task, responses=responses, miner_uids=miner_uids)
+    rewards, results = get_rewards(self, task=task, responses=responses, miner_uids=miner_uids.tolist())
 
     bt.logging.info(f"Scored responses: {rewards}")
     # Update the scores based on the rewards. You may want to define your own update_scores function for custom behavior.

--- a/bitagent/validator/forward.py
+++ b/bitagent/validator/forward.py
@@ -62,7 +62,7 @@ async def forward(self):
 
     # Adjust the scores based on responses from miners.
     # also gets results for feedback to the miners
-    rewards, results = get_rewards(self, task=task, responses=responses)
+    rewards, results = get_rewards(self, task=task, responses=responses, miner_uids=miner_uids)
 
     bt.logging.info(f"Scored responses: {rewards}")
     # Update the scores based on the rewards. You may want to define your own update_scores function for custom behavior.

--- a/bitagent/validator/reward.py
+++ b/bitagent/validator/reward.py
@@ -22,14 +22,14 @@ from bitagent.validator.tasks import Task
 from common.base.validator import BaseValidatorNeuron
 
 def get_rewards(validator: BaseValidatorNeuron, task: Task, responses: List[str], 
-                miner_uids: List[torch.LongTensor]) -> [torch.FloatTensor, List[str]]:
+                miner_uids: List[int]) -> [torch.FloatTensor, List[str]]:
     """
     Returns a tensor of rewards for the given query and responses.
 
     Args:
     - task (Task): The task sent to the miner.
     - responses (List[float]): A list of responses from the miner.
-    - miner_uids (List[torch.LongTensor]): A list of miner UIDs. The miner at a particular index has a response in responses at the same index.
+    - miner_uids (List[int]): A list of miner UIDs. The miner at a particular index has a response in responses at the same index.
 
     Returns:
     - torch.FloatTensor: A tensor of rewards for the given query and responses.

--- a/bitagent/validator/reward.py
+++ b/bitagent/validator/reward.py
@@ -21,13 +21,15 @@ from typing import List
 from bitagent.validator.tasks import Task
 from common.base.validator import BaseValidatorNeuron
 
-def get_rewards(validator: BaseValidatorNeuron, task: Task, responses: List[str]) -> [torch.FloatTensor, List[str]]:
+def get_rewards(validator: BaseValidatorNeuron, task: Task, responses: List[str], 
+                miner_uids: List[torch.LongTensor]) -> [torch.FloatTensor, List[str]]:
     """
     Returns a tensor of rewards for the given query and responses.
 
     Args:
     - task (Task): The task sent to the miner.
     - responses (List[float]): A list of responses from the miner.
+    - miner_uids (List[torch.LongTensor]): A list of miner UIDs. The miner at a particular index has a response in responses at the same index.
 
     Returns:
     - torch.FloatTensor: A tensor of rewards for the given query and responses.


### PR DESCRIPTION
`get_rewards` accepts the list of miner UIDs that will be rewarded. Each index in `miner_uids` corresponds to the same index in `responses`. This makes it possible to map each response to the miner that gave the response. This is useful for modified validators that wish to save key data and metrics about the miners on the subnet. 

For example, a validator may call a custom backend following the `results.append` statement:

```
miner_uid_value = miner_uids[index].item()

data = {
    "uid": json.dumps(miner_uid_value),
    "is_testing": False,
    "hotkey": "",
    "coldkey": "",
    "score": score,
    "task_results": "\n".join(task_results),
    "response": json.dumps(response.response),
    "response_urls": json.dumps(response.urls),
    "response_datas": json.dumps(response.datas),
    "response_prompt": json.dumps(response.prompt),
    "subnet": 20,
    "max_possible_score": max_possible_score,
    "normalized_score": normalized_score
}

url = "<api-url>"
save_request = requests.post(url, json.dumps(data))
if save_request.status_code < 400:
    bt.logging.info(f"Saved score [Miner ID: {miner_uids[index]}]")
else:
    bt.logging.info(f"Error saving scores {save_request.text}")
```

By including the `miner_uids`, each response in `responses` can be mapped to the miner.