### PR TITLE
Introduce a penalty for incorrect citations in qna tasks.

### DIFF
--- a/bitagent/task_api/criteria/qna_criteria.py
+++ b/bitagent/task_api/criteria/qna_criteria.py
@@ -137,11 +137,14 @@ def contains_correct_number_of_citation_sources(task, validator: BaseValidatorNe
     for source in sources:
         if source in selected_sources:
             identified_sources += 1
-            score += 1.5/len(selected_sources)
+            score += 1.5 / len(selected_sources)
+        else:
+            # 50% penalty for wrong source
+            score -= 0.75 / len(selected_sources)
 
-    reward = score
+    reward = max(-max_reward, score)
     if score > 0.0:
-        feedback = good_message(f"You correctly identified some or all of the correct citation sources ({identified_sources}/{len(selected_sources)} identified).")
+        feedback = good_message(f"You submitted {len(sources)} sources and correctly identified some or all of the correct citation sources ({identified_sources}/{len(selected_sources)} identified).")
     else:
         feedback = bad_message(f"You failed to correctly identify any of the correct citation sources.")
         feedback += f"\nYou provided the following sources: {sources}."


### PR DESCRIPTION
Introduce a penalty for incorrect citations in the QnA criteria to prevent miners from cheating by providing all of the data sources.